### PR TITLE
fix: add CardPreview to all the pages with card grid

### DIFF
--- a/app/decks/[id]/page.tsx
+++ b/app/decks/[id]/page.tsx
@@ -2,11 +2,12 @@
 
 import { useParams, useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { CardsGrid } from "@/app/search/CardsGrid"
 import { useDeck } from "@/app/search/DeckContext"
 import { sortCards } from "@/lib/deckUtils.client"
 import { CardDotCounter } from "../edit/CardDotCounter"
+import { CardPreviewPortal } from "../edit/CardPreviewPortal"
 import { DeckSectionHeading } from "../edit/DeckColumn"
 import { useDecksMutation } from "../useDecksMutation"
 import { useDeckQuery } from "./useDeckQuery"
@@ -36,8 +37,9 @@ function Deck() {
 
   const router = useRouter()
   const { deck: activeDeck, setDeckId } = useDeck()
-
   const { deleteDeck, isFetching: isMutationRunning } = useDecksMutation()
+
+  const [activeCard, setActiveCard] = useState<Card | null>(null)
 
   const cardsExceptChampions = useMemo(() => {
     const filtered = deck?.cards?.filter(
@@ -130,6 +132,7 @@ function Deck() {
           <CardsGrid
             data={champions}
             counters={counters}
+            onCardClick={card => setActiveCard(card)}
             cardHeaderFn={card => (
               <CardDotCounter card={card} counters={counters} visible={false} />
             )}
@@ -145,6 +148,7 @@ function Deck() {
           <CardsGrid
             data={cardsExceptChampions}
             counters={counters}
+            onCardClick={card => setActiveCard(card)}
             cardHeaderFn={card => (
               <CardDotCounter card={card} counters={counters} visible={false} />
             )}
@@ -153,6 +157,8 @@ function Deck() {
           <div className="text-center my-7 text-sm text-zinc-600/60">Empty deck</div>
         )}
       </div>
+
+      {activeCard && <CardPreviewPortal card={activeCard} onClick={() => setActiveCard(null)} />}
     </section>
   )
 }

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -3,6 +3,7 @@ import Image from "next/image"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useDeck } from "@/app/search/DeckContext"
 import { ScryRulings } from "@/app/search/ScryfallAPI"
+import { cn } from "@/lib/utils"
 import type { Card, Ruling } from "scryfall-sdk"
 
 type Props = {
@@ -68,18 +69,29 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
 
   return (
     <div
-      className="
-        bg-gray-600/95 backdrop-blur-0 text-gray-200
-        @container/main
-        absolute left-0 top-0 w-full
-        cursor-pointer
-        overflow-auto
-      "
+      className={cn(
+        "bg-gray-600/95 backdrop-blur-0 text-gray-200",
+        "@container/main",
+        "absolute left-0 top-0 w-full",
+        "cursor-pointer",
+        // note: scroll only for w < @3xl, after this bp we set fixed height and move scroll to the "About the card" container
+        "overflow-y-auto",
+        showChampionButtons
+          ? "[--preview-header-vh:2.4rem] [--preview-main-vh:calc(100%_-_var(--preview-header-vh))]"
+          : "[--preview-main-vh:100%]"
+      )}
       style={{ height }}
       onClick={onClick}
     >
       {showChampionButtons && (
-        <div className="py-3 px-4 flex gap-1 justify-center text-sm">
+        <div
+          className="
+            px-4
+            flex gap-1 justify-center items-center
+            text-sm
+            h-[var(--preview-header-vh)]
+          "
+        >
           <button
             className="px-2 py-0.5 rounded-sm bg-orange-400 hover:opacity-80 disabled:opacity-30"
             disabled={!canAddChampion}
@@ -105,10 +117,10 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
 
       <div
         className="
-        h-max flex flex-col
-        @4xl/main:flex-row
-        @4xl/main:h-full
-      "
+          h-max flex flex-col
+          @3xl/main:flex-row
+          @3xl/main:h-[var(--preview-main-vh)]
+        "
       >
         {/* card image */}
         <div
@@ -116,7 +128,7 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
           flex justify-center items-center
           flex-grow flex-shrink-0
           px-2 py-6
-          @4xl/main:justify-end
+          @3xl/main:justify-end
         "
         >
           {card.image_uris && (
@@ -124,7 +136,7 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
               className="
                 magic-card w-max
                 h-[clamp(60vmax,28rem,90vmax)]
-                @4xl/main:h-[clamp(70vmin,28rem,90vmin)]
+                @3xl/main:h-[clamp(70vmin,28rem,90vmin)]
               "
               src={card.image_uris?.normal || card.image_uris.png}
               height={320}
@@ -139,10 +151,10 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
           className="
             my-auto px-5
             flex justify-center flex-grow
-            @4xl/main:max-h-full
-            @4xl/main:overflow-y-auto
-            @4xl/main:px-2
-            @4xl/main:basis-[36rem]
+            @3xl/main:max-h-full
+            @3xl/main:overflow-y-auto
+            @3xl/main:px-2
+            @3xl/main:basis-[36rem]
           "
         >
           {/* <div className="mt-3 flex flex-col items-center gap-6">
@@ -157,7 +169,7 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
               flex flex-col gap-3
               h-max w-full max-w-[36rem]
               mt-2 mb-10
-              @4xl/main:mt-10
+              @3xl/main:mt-10
             "
           >
             {/* keywords */}

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useDeck } from "@/app/search/DeckContext"
 import { ScryRulings } from "@/app/search/ScryfallAPI"
 import { cn } from "@/lib/utils"
+import type { KeyboardEventHandler } from "react"
 import type { Card, Ruling } from "scryfall-sdk"
 
 export type CardPreviewProps = {
@@ -48,6 +49,12 @@ export function CardPreview({
     return () => ac.abort()
   }, [card])
 
+  const handleKeyEsc: KeyboardEventHandler = e => {
+    if (e.key === "Escape") onClick()
+    console.log("🚀 | handleEsc | e:", e)
+    console.log("🚀 | handleEsc | e.key:", e.key)
+  }
+
   // ------------------------------------------------------------------
   //                         handle champions
   // ------------------------------------------------------------------
@@ -89,6 +96,9 @@ export function CardPreview({
       style={{ height }}
       onClick={onClick}
     >
+      {/* hidden input for keyboard events */}
+      <input className="absolute top-0 left-0 opacity-0 h-0" autoFocus onKeyDown={handleKeyEsc} />
+
       {showChampionButtons && (
         <div
           className="

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -6,7 +6,7 @@ import { ScryRulings } from "@/app/search/ScryfallAPI"
 import { cn } from "@/lib/utils"
 import type { Card, Ruling } from "scryfall-sdk"
 
-type Props = {
+export type CardPreviewProps = {
   card: Card
   isInDeck: boolean
   showChampionButtons: boolean
@@ -14,7 +14,13 @@ type Props = {
   onClick: () => void
 }
 
-export function CardPreview({ card, isInDeck, showChampionButtons, height, onClick }: Props) {
+export function CardPreview({
+  card,
+  isInDeck,
+  showChampionButtons,
+  height,
+  onClick,
+}: CardPreviewProps) {
   const [rulings, setRulings] = useState<Ruling[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
   console.log("🚀 | CardPreview | isLoading:", isLoading)

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -20,19 +20,10 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
   console.log("🚀 | CardPreview | isLoading:", isLoading)
 
   useEffect(() => {
-    const el = document.documentElement
-
-    el.style.cssText += `
-      position: fixed;
-      left: 0;
-      width: 100%;
-      top: -${el.scrollTop}px;
-    `
+    document.documentElement.style.overflow = "hidden"
 
     return () => {
-      const scrollY = el.style.top
-      el.style.cssText = ""
-      el.scrollTo(0, parseInt(scrollY || "0") * -1)
+      document.documentElement.style.overflow = "auto"
     }
   }, [])
 

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -68,14 +68,13 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
   // ------------------------------------------------------------------
 
   return (
-    <dialog
-      id="CardPreview__dialog"
-      open
+    <div
       className="
         bg-gray-600/95 backdrop-blur-0 text-gray-200
         px-3
         absolute left-0 top-0 w-full
         cursor-pointer
+        overflow-auto
       "
       style={{ height }}
       onClick={onClick}
@@ -163,6 +162,6 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
           </div>
         </div>
       </div>
-    </dialog>
+    </div>
   )
 }

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -3,7 +3,6 @@ import Image from "next/image"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useDeck } from "@/app/search/DeckContext"
 import { ScryRulings } from "@/app/search/ScryfallAPI"
-import { cn } from "@/lib/utils"
 import type { Card, Ruling } from "scryfall-sdk"
 
 type Props = {
@@ -71,6 +70,7 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
     <div
       className="
         bg-gray-600/95 backdrop-blur-0 text-gray-200
+        @container/main
         absolute left-0 top-0 w-full
         cursor-pointer
         overflow-auto
@@ -103,11 +103,29 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
         </div>
       )}
 
-      <div className="h-full flex flex-row">
-        <div className="flex flex-col flex-grow justify-center items-end flex-shrink-0 px-2">
+      <div
+        className="
+        h-max flex flex-col
+        @4xl/main:flex-row
+        @4xl/main:h-full
+      "
+      >
+        {/* card image */}
+        <div
+          className="
+          flex justify-center items-center
+          flex-grow flex-shrink-0
+          px-2 py-6
+          @4xl/main:justify-end
+        "
+        >
           {card.image_uris && (
             <Image
-              className="magic-card h-[clamp(70vh,28rem,90vh)] w-max"
+              className="
+                magic-card w-max
+                h-[clamp(60vmax,28rem,90vmax)]
+                @4xl/main:h-[clamp(70vmin,28rem,90vmin)]
+              "
               src={card.image_uris?.normal || card.image_uris.png}
               height={320}
               width={240}
@@ -115,11 +133,16 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
             />
           )}
         </div>
+
+        {/* about the card */}
         <div
           className="
-            max-h-full my-auto px-2
-            flex justify-center flex-grow basis-[36rem]
-            overflow-y-auto
+            my-auto px-5
+            flex justify-center flex-grow
+            @4xl/main:max-h-full
+            @4xl/main:overflow-y-auto
+            @4xl/main:px-2
+            @4xl/main:basis-[36rem]
           "
         >
           {/* <div className="mt-3 flex flex-col items-center gap-6">
@@ -129,7 +152,14 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
             </span>
           </div> */}
 
-          <div className="flex flex-col gap-3 h-max w-full my-10 max-w-[36rem]">
+          <div
+            className="
+              flex flex-col gap-3
+              h-max w-full max-w-[36rem]
+              mt-2 mb-10
+              @4xl/main:mt-10
+            "
+          >
             {/* keywords */}
             <>
               <hr className="opacity-25" />

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -9,12 +9,32 @@ import type { Card, Ruling } from "scryfall-sdk"
 type Props = {
   card: Card
   isInDeck: boolean
+  showChampionButtons: boolean
+  height: string
   onClick: () => void
 }
 
-export function CardPreview({ card, isInDeck, onClick }: Props) {
+export function CardPreview({ card, isInDeck, showChampionButtons, height, onClick }: Props) {
   const [rulings, setRulings] = useState<Ruling[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  console.log("🚀 | CardPreview | isLoading:", isLoading)
+
+  useEffect(() => {
+    const el = document.documentElement
+
+    el.style.cssText += `
+      position: fixed;
+      left: 0;
+      width: 100%;
+      top: -${el.scrollTop}px;
+    `
+
+    return () => {
+      const scrollY = el.style.top
+      el.style.cssText = ""
+      el.scrollTo(0, parseInt(scrollY || "0") * -1)
+    }
+  }, [])
 
   useEffect(() => {
     if (!card) return
@@ -57,37 +77,42 @@ export function CardPreview({ card, isInDeck, onClick }: Props) {
   // ------------------------------------------------------------------
 
   return (
-    <div
+    <dialog
+      id="CardPreview__dialog"
+      open
       className="
         bg-gray-600/95 backdrop-blur-0 text-gray-200
         px-3
-        fixed top-12 bottom-0 left-64 right-0
+        absolute left-0 top-0 w-full
         cursor-pointer
       "
+      style={{ height }}
       onClick={onClick}
     >
-      <div className="py-3 px-4 flex gap-1 justify-center text-sm">
-        <button
-          className="px-2 py-0.5 rounded-sm bg-orange-400 hover:opacity-80 disabled:opacity-30"
-          disabled={!canAddChampion}
-          onClick={e => {
-            e.stopPropagation()
-            handleAddChampion()
-          }}
-        >
-          Add to champions
-        </button>
-        <button
-          className="px-2 py-0.5 rounded-sm bg-orange-400 hover:opacity-80 disabled:opacity-30"
-          disabled={!canRemoveChampion}
-          onClick={e => {
-            e.stopPropagation()
-            handleRemoveChampion()
-          }}
-        >
-          Remove from champions
-        </button>
-      </div>
+      {showChampionButtons && (
+        <div className="py-3 px-4 flex gap-1 justify-center text-sm">
+          <button
+            className="px-2 py-0.5 rounded-sm bg-orange-400 hover:opacity-80 disabled:opacity-30"
+            disabled={!canAddChampion}
+            onClick={e => {
+              e.stopPropagation()
+              handleAddChampion()
+            }}
+          >
+            Add to champions
+          </button>
+          <button
+            className="px-2 py-0.5 rounded-sm bg-orange-400 hover:opacity-80 disabled:opacity-30"
+            disabled={!canRemoveChampion}
+            onClick={e => {
+              e.stopPropagation()
+              handleRemoveChampion()
+            }}
+          >
+            Remove from champions
+          </button>
+        </div>
+      )}
 
       <div className="flex flex-row gap-5">
         <div className="flex flex-col justify-center items-center flex-shrink-0">
@@ -119,33 +144,34 @@ export function CardPreview({ card, isInDeck, onClick }: Props) {
           </div> */}
 
           <div className="flex flex-col gap-3 my-10" style={{ maxWidth: "36rem" }}>
-            {card.keywords.length ? (
-              <>
-                <hr className="opacity-25" />
-                <div>
-                  <span className="font-bold mb-3">Keywords: </span>
-                  {card.keywords.map(k => (
-                    <span key={card.id + k}>{k + " "}</span>
-                  ))}
-                </div>
-                <hr className="opacity-25" />
-              </>
-            ) : null}
+            {/* keywords */}
+            <>
+              <hr className="opacity-25" />
+              <div>
+                <span className="font-bold mb-3">Keywords: </span>
+                {!!card.keywords.length &&
+                  card.keywords.map(k => <span key={card.id + k}>{k + " "}</span>)}
+                {!card.keywords.length && <span>no keywords</span>}
+              </div>
+              <hr className="opacity-25" />
+            </>
 
-            <h2 className="font-bold mb-3">Rulings:</h2>
-            {isLoading ? (
-              <div>loading...</div>
-            ) : (
+            <div className="flex gap-2">
+              <h2 className="font-bold mb-3">Rulings:</h2>
+              {isLoading && <div>loading...</div>}
+              {!isLoading && rulings.length === 0 && <div>no rulings found</div>}
+            </div>
+            {!isLoading &&
+              !!rulings.length &&
               rulings.map((r, i) => (
                 <div key={card.id + "rule_" + i}>
                   <p>{r.comment}</p>
                   <p>({r.published_at})</p>
                 </div>
-              ))
-            )}
+              ))}
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
   )
 }

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -71,7 +71,6 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
     <div
       className="
         bg-gray-600/95 backdrop-blur-0 text-gray-200
-        px-3
         absolute left-0 top-0 w-full
         cursor-pointer
         overflow-auto
@@ -104,27 +103,24 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
         </div>
       )}
 
-      <div className="flex flex-row gap-5">
-        <div className="flex flex-col justify-center items-center flex-shrink-0">
+      <div className="h-full flex flex-row">
+        <div className="flex flex-col flex-grow justify-center items-end flex-shrink-0 px-2">
           {card.image_uris && (
             <Image
-              className={cn("magic-card h-auto w-max")}
+              className="magic-card h-[clamp(70vh,28rem,90vh)] w-max"
               src={card.image_uris?.normal || card.image_uris.png}
               height={320}
               width={240}
-              style={{
-                height: "min(90vh, 400px)",
-              }}
               alt={card.name}
             />
           )}
-
-          {/* <div>{card.flavor_text}</div> */}
-          {/* <div>rarity: {card.rarity}</div> */}
         </div>
         <div
-          className="overflow-y-scroll my-auto flex justify-center"
-          style={{ maxHeight: "calc(100vh - 7rem)", flexGrow: 2 }}
+          className="
+            max-h-full my-auto px-2
+            flex justify-center flex-grow basis-[36rem]
+            overflow-y-auto
+          "
         >
           {/* <div className="mt-3 flex flex-col items-center gap-6">
             <div>{<ChevronDown />}</div>
@@ -133,7 +129,7 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
             </span>
           </div> */}
 
-          <div className="flex flex-col gap-3 my-10" style={{ maxWidth: "36rem" }}>
+          <div className="flex flex-col gap-3 h-max w-full my-10 max-w-[36rem]">
             {/* keywords */}
             <>
               <hr className="opacity-25" />
@@ -143,11 +139,15 @@ export function CardPreview({ card, isInDeck, showChampionButtons, height, onCli
                   card.keywords.map(k => <span key={card.id + k}>{k + " "}</span>)}
                 {!card.keywords.length && <span>no keywords</span>}
               </div>
+              <div>
+                <span className="font-bold mb-3">Rarity: </span>
+                {card.rarity}
+              </div>
               <hr className="opacity-25" />
             </>
 
             <div className="flex gap-2">
-              <h2 className="font-bold mb-3">Rulings:</h2>
+              <h2 className="font-bold">Rulings:</h2>
               {isLoading && <div>loading...</div>}
               {!isLoading && rulings.length === 0 && <div>no rulings found</div>}
             </div>

--- a/app/decks/edit/CardPreview.tsx
+++ b/app/decks/edit/CardPreview.tsx
@@ -51,8 +51,6 @@ export function CardPreview({
 
   const handleKeyEsc: KeyboardEventHandler = e => {
     if (e.key === "Escape") onClick()
-    console.log("🚀 | handleEsc | e:", e)
-    console.log("🚀 | handleEsc | e.key:", e.key)
   }
 
   // ------------------------------------------------------------------

--- a/app/decks/edit/CardPreviewPortal.tsx
+++ b/app/decks/edit/CardPreviewPortal.tsx
@@ -1,0 +1,22 @@
+import { createPortal } from "react-dom"
+import { CardPreview } from "./CardPreview"
+import type { CardPreviewProps } from "./CardPreview"
+
+export function CardPreviewPortal({ card, onClick }: Pick<CardPreviewProps, "card" | "onClick">) {
+  const portalNode = document.getElementById("portal-root")
+
+  return (
+    portalNode &&
+    createPortal(
+      <CardPreview
+        showChampionButtons={false}
+        isInDeck={false}
+        height="100dvh"
+        card={card}
+        onClick={onClick}
+      />,
+      portalNode,
+      "CardPreview"
+    )
+  )
+}

--- a/app/decks/edit/page.tsx
+++ b/app/decks/edit/page.tsx
@@ -38,12 +38,9 @@ export default function DeckPage() {
   return (
     <section
       className="
-        border-0 border-red-500
         flex-auto flex flex-row w-full
+        max-h-[--layout-main-vh]
       "
-      style={{
-        maxHeight: "calc(100vh - 3rem)",
-      }}
     >
       {/* sidebar */}
       <article
@@ -131,7 +128,7 @@ export default function DeckPage() {
           {activeCard && (
             <CardPreview
               showChampionButtons={true}
-              height="calc(100vh - 3rem)"
+              height="var(--layout-main-vh)"
               isInDeck={isActiveCardInDeck}
               card={activeCard}
               onClick={() => setActiveCard(null)}

--- a/app/decks/edit/page.tsx
+++ b/app/decks/edit/page.tsx
@@ -89,52 +89,56 @@ export default function DeckPage() {
       </article>
 
       {/* Search -> Card Grid */}
-      <article
-        className="flex-auto flex items-center flex-col overflow-y-auto"
-        style={{
-          fontSize: "0.92em",
-        }}
-      >
-        <SearchForm
-          query=""
-          onSubmit={e => {
-            e.preventDefault()
-            const target = e.target as unknown as { search: HTMLInputElement }
-            const q = target?.search?.value
-            if (!q) return
-
-            setQuery(q.replaceAll(" ", "+"))
+      <div className="relative w-full border-0 border-red-500 box-border">
+        <article
+          className="flex-auto flex items-center flex-col overflow-y-auto h-full"
+          style={{
+            fontSize: "0.92em",
           }}
-        />
+        >
+          <SearchForm
+            query=""
+            onSubmit={e => {
+              e.preventDefault()
+              const target = e.target as unknown as { search: HTMLInputElement }
+              const q = target?.search?.value
+              if (!q) return
 
-        {query ? (
-          <SearchOutput
-            query={query}
-            counters={counters}
-            onCardClick={card => setActiveCard(card)}
-            cardHeaderFn={(card, counters, visible) => (
-              <CardDotCounter
-                card={card}
-                counters={counters}
-                addCard={deck.addCard}
-                removeCard={deck.removeCard}
-                visible={visible}
-              />
-            )}
+              setQuery(q.replaceAll(" ", "+"))
+            }}
           />
-        ) : (
-          <div>Empty query</div>
-        )}
 
-        {/* overlay */}
-        {activeCard && (
-          <CardPreview
-            isInDeck={isActiveCardInDeck}
-            card={activeCard}
-            onClick={() => setActiveCard(null)}
-          />
-        )}
-      </article>
+          {query ? (
+            <SearchOutput
+              query={query}
+              counters={counters}
+              onCardClick={card => setActiveCard(card)}
+              cardHeaderFn={(card, counters, visible) => (
+                <CardDotCounter
+                  card={card}
+                  counters={counters}
+                  addCard={deck.addCard}
+                  removeCard={deck.removeCard}
+                  visible={visible}
+                />
+              )}
+            />
+          ) : (
+            <div>Empty query</div>
+          )}
+
+          {/* overlay */}
+          {activeCard && (
+            <CardPreview
+              showChampionButtons={true}
+              height="calc(100vh - 3rem)"
+              isInDeck={isActiveCardInDeck}
+              card={activeCard}
+              onClick={() => setActiveCard(null)}
+            />
+          )}
+        </article>
+      </div>
     </section>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -74,9 +74,16 @@
   * {
     @apply border-border;
   }
+
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
+  }
+
+  html,
+  body {
+    scrollbar-gutter: stable;
+    overscroll-behavior: none;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css"
 import { Inter } from "next/font/google"
+import { cn } from "@/lib/utils"
 import { Navbar } from "./navbar"
 import { Providers } from "./providers"
 
@@ -13,12 +14,17 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={font.className}>
+      <body
+        className={cn(
+          font.className,
+          "[--layout-header-vh:3rem] [--layout-main-vh:calc(100vh_-_var(--layout-header-vh))]"
+        )}
+      >
         {/* header */}
         <div
           className="
           w-full
-          flex justify-center h-12 items-center
+          flex justify-center h-[--layout-header-vh] items-center
           bg-gradient-to-b from-zinc-900/95 to-zinc-800/95
           text-zinc-200
           "
@@ -26,7 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Navbar />
         </div>
 
-        <main className="flex flex-col items-center" style={{ minHeight: "calc(100vh - 3rem)" }}>
+        <main className="flex flex-col items-center min-h-[--layout-main-vh]">
           <Providers>{children}</Providers>
         </main>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import "./globals.css"
 import { Inter } from "next/font/google"
-import { cn } from "@/lib/utils"
 import { Navbar } from "./navbar"
 import { Providers } from "./providers"
 
@@ -14,7 +13,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={cn(font.className, "overscroll-none")}>
+      <body className={font.className}>
         {/* header */}
         <div
           className="
@@ -30,6 +29,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <main className="flex flex-col items-center" style={{ minHeight: "calc(100vh - 3rem)" }}>
           <Providers>{children}</Providers>
         </main>
+
+        <div id="portal-root" className="fixed top-0 left-0 w-full h-0 z-10"></div>
       </body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body
         className={cn(
           font.className,
-          "[--layout-header-vh:3rem] [--layout-main-vh:calc(100vh_-_var(--layout-header-vh))]"
+          "[--layout-header-vh:3rem] [--layout-main-vh:calc(100dvh_-_var(--layout-header-vh))]"
         )}
       >
         {/* header */}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -26,7 +26,7 @@ import type { Card, SearchOptions } from "scryfall-sdk"
  * #### formats
  * https://magic.wizards.com/en/formats
  */
-export default async function Search(props: {
+export default function Search(props: {
   searchParams?: {
     q?: string
   } & SearchOptions

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { createPortal } from "react-dom"
-import { CardPreview } from "../decks/edit/CardPreview"
+import { CardPreviewPortal } from "../decks/edit/CardPreviewPortal"
 import { SearchInput } from "./SearchInput"
 import { SearchOutput } from "./SearchOutput"
 import type { Card, SearchOptions } from "scryfall-sdk"
@@ -33,8 +32,6 @@ export default function Search(props: {
 }) {
   const [activeCard, setActiveCard] = useState<Card | null>(null)
 
-  const portalNode = document.getElementById("portal-root")
-
   return (
     <>
       <SearchInput />
@@ -48,19 +45,9 @@ export default function Search(props: {
           />
 
           {/* https://react.dev/reference/react-dom/createPortal */}
-          {activeCard &&
-            portalNode &&
-            createPortal(
-              <CardPreview
-                showChampionButtons={false}
-                isInDeck={false}
-                height="100dvh"
-                card={activeCard}
-                onClick={() => setActiveCard(null)}
-              />,
-              portalNode,
-              "CardPreview"
-            )}
+          {activeCard && (
+            <CardPreviewPortal card={activeCard} onClick={() => setActiveCard(null)} />
+          )}
         </>
       ) : (
         <div>Empty query</div>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -54,7 +54,7 @@ export default function Search(props: {
               <CardPreview
                 showChampionButtons={false}
                 isInDeck={false}
-                height="100vh"
+                height="100dvh"
                 card={activeCard}
                 onClick={() => setActiveCard(null)}
               />,

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,6 +1,11 @@
+"use client"
+
+import { useState } from "react"
+import { createPortal } from "react-dom"
+import { CardPreview } from "../decks/edit/CardPreview"
 import { SearchInput } from "./SearchInput"
 import { SearchOutput } from "./SearchOutput"
-import type { SearchOptions } from "scryfall-sdk"
+import type { Card, SearchOptions } from "scryfall-sdk"
 
 /**
  * #### Scryfall routes
@@ -26,13 +31,37 @@ export default async function Search(props: {
     q?: string
   } & SearchOptions
 }) {
+  const [activeCard, setActiveCard] = useState<Card | null>(null)
+
+  const portalNode = document.getElementById("portal-root")
+
   return (
     <>
       <SearchInput />
-      {/* <Suspense fallback={<div>Loading...</div>}>
-      </Suspense> */}
+
       {props.searchParams?.q ? (
-        <SearchOutput query={props.searchParams.q} options={props.searchParams} />
+        <>
+          <SearchOutput
+            query={props.searchParams.q}
+            options={props.searchParams}
+            onCardClick={card => setActiveCard(card)}
+          />
+
+          {/* https://react.dev/reference/react-dom/createPortal */}
+          {activeCard &&
+            portalNode &&
+            createPortal(
+              <CardPreview
+                showChampionButtons={false}
+                isInDeck={false}
+                height="100vh"
+                card={activeCard}
+                onClick={() => setActiveCard(null)}
+              />,
+              portalNode,
+              "CardPreview"
+            )}
+        </>
       ) : (
         <div>Empty query</div>
       )}


### PR DESCRIPTION
add CardPreview to pages:
- `/search`
- `/deck/edit`
- `/deck/[id]`

fixes:
- refactor, using Portal
- add responsive layout, using container query over `main` container
- handle Esc keydown event
